### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/StdAfx.h
+++ b/StdAfx.h
@@ -11,6 +11,7 @@
 
 #include <list>
 #include <algorithm>
+#include <new>
 
 // Speed up our string conversions for output
 #ifdef MRMAPI

--- a/UI/Dialogs/AboutDlg.cpp
+++ b/UI/Dialogs/AboutDlg.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include <UI/Dialogs/AboutDlg.h>
 #include <UI/UIFunctions.h>
+#include <new>
 
 void DisplayAboutDlg(_In_ CWnd* lpParentWnd)
 {

--- a/UI/Dialogs/AboutDlg.cpp
+++ b/UI/Dialogs/AboutDlg.cpp
@@ -118,10 +118,9 @@ BOOL CAboutDlg::OnInitDialog()
 	if (dwVerInfoSize)
 	{
 		// If we were able to get the information, process it.
-		auto pbData = new BYTE[dwVerInfoSize];
+		try {
+			auto pbData = new BYTE[dwVerInfoSize];
 
-		if (pbData)
-		{
 			EC_D(bRet, GetFileVersionInfoW(szFullPath,
 				0, dwVerInfoSize, static_cast<void*>(pbData)));
 
@@ -170,12 +169,14 @@ BOOL CAboutDlg::OnInitDialog()
 						::SetDlgItemTextW(m_hWnd, i, pszVer);
 					}
 				}
-			}
 
-			delete[] pbData;
+				delete[] pbData;
+			}
+		}
+		catch (std::bad_alloc& ba) {
+
 		}
 	}
-
 	return bRet;
 }
 

--- a/UI/Dialogs/AboutDlg.cpp
+++ b/UI/Dialogs/AboutDlg.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include <UI/Dialogs/AboutDlg.h>
 #include <UI/UIFunctions.h>
-#include <new>
 
 void DisplayAboutDlg(_In_ CWnd* lpParentWnd)
 {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'pbData' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. aboutdlg.cpp 123