### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/FileDialogEx.cpp
+++ b/UI/FileDialogEx.cpp
@@ -163,12 +163,13 @@ _Check_return_ INT_PTR CFileDialogExW::DisplayDialog(
 	LPWSTR szBigBuff = nullptr;
 	if (dwFlags & OFN_ALLOWMULTISELECT)
 	{
-		szBigBuff = new WCHAR[CCHBIGBUFF];
-		if (szBigBuff)
-		{
+		try {
+			szBigBuff = new WCHAR[CCHBIGBUFF];
 			szBigBuff[0] = 0; // NULL terminate
 			ofn.lpstrFile = szBigBuff;
 			ofn.nMaxFile = CCHBIGBUFF;
+		}
+		catch (std::bad_alloc& ba) {
 		}
 	}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'szBigBuff' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. filedialogex.cpp 167