### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/Controls/HierarchyTableTreeCtrl.cpp
+++ b/UI/Controls/HierarchyTableTreeCtrl.cpp
@@ -332,9 +332,9 @@ _Check_return_ HRESULT CHierarchyTableTreeCtrl::AddRootNode(_In_ LPMAPICONTAINER
 		szName = loadstring(IDS_ROOTCONTAINER);
 	}
 
-	auto lpData = new SortListData();
-	if (lpData)
-	{
+	try {
+		auto lpData = new SortListData();
+
 		lpData->InitializeNode(
 			cVals,
 			lpProps, // pass our lpProps to be archived
@@ -348,6 +348,9 @@ _Check_return_ HRESULT CHierarchyTableTreeCtrl::AddRootNode(_In_ LPMAPICONTAINER
 			TVI_ROOT,
 			lpData,
 			true);
+
+	}
+	catch (std::bad_alloc& ba) {
 	}
 
 	// Node owns the lpProps memory now, so we don't free it
@@ -398,9 +401,9 @@ void CHierarchyTableTreeCtrl::AddNode(_In_ LPSRow lpsRow, HTREEITEM hParent, boo
 	}
 	DebugPrintEx(DBGHierarchy, CLASS, L"AddNode", L"Adding to %p: %ws\n", hParent, szName.c_str());
 
-	auto lpData = new SortListData();
-	if (lpData)
-	{
+	try {
+		auto lpData = new SortListData();
+
 		lpData->InitializeNode(lpsRow);
 
 		AddNode(
@@ -408,6 +411,8 @@ void CHierarchyTableTreeCtrl::AddNode(_In_ LPSRow lpsRow, HTREEITEM hParent, boo
 			hParent,
 			lpData,
 			bGetTable);
+	}
+	catch (std::bad_alloc& ba) {
 	}
 }
 
@@ -1161,11 +1166,13 @@ _Check_return_ LRESULT CHierarchyTableTreeCtrl::msgOnModifyItem(WPARAM wParam, L
 			tab->row.lpProps,
 			MAPIAllocateBuffer,
 			&NewRow.lpProps));
-		auto lpData = new SortListData();
-		if (lpData)
-		{
+
+		try {
+			auto lpData = new SortListData();
 			lpData->InitializeNode(&NewRow);
 			SetNodeData(m_hWnd, hModifyItem, lpData);
+		}
+		catch (std::bad_alloc& ba) {
 		}
 
 		if (hParent) EC_B(SortChildren(hParent));

--- a/UI/Dialogs/HierarchyTable/HierarchyTableDlg.cpp
+++ b/UI/Dialogs/HierarchyTable/HierarchyTableDlg.cpp
@@ -228,18 +228,18 @@ BOOL CHierarchyTableDlg::OnInitDialog()
 
 	if (m_lpFakeSplitter)
 	{
-		m_lpHierarchyTableTreeCtrl = new CHierarchyTableTreeCtrl(
-			m_lpFakeSplitter,
-			m_lpMapiObjects,
-			this,
-			m_ulDisplayFlags,
-			m_nIDContextMenu);
+		try {
+			m_lpHierarchyTableTreeCtrl = new CHierarchyTableTreeCtrl(
+				m_lpFakeSplitter,
+				m_lpMapiObjects,
+				this,
+				m_ulDisplayFlags,
+				m_nIDContextMenu);
 
-		if (m_lpHierarchyTableTreeCtrl)
-		{
 			m_lpFakeSplitter->SetPaneOne(m_lpHierarchyTableTreeCtrl);
-
 			m_lpFakeSplitter->SetPercent(0.25);
+		}
+		catch (std::bad_alloc& ba) {
 		}
 	}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. hierarchytable*