### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Interpret/InterpretProp2.cpp
+++ b/Interpret/InterpretProp2.cpp
@@ -289,10 +289,11 @@ LPCGUID GUIDNameToGUID(_In_ const wstring& szGUID, bool bByteSwapped)
 
 	if (lpGUID)
 	{
-		lpGuidRet = new GUID;
-		if (lpGuidRet)
-		{
+		try {
+			lpGuidRet = new GUID;
 			memcpy(lpGuidRet, lpGUID, sizeof(GUID));
+		}
+		catch (std::bad_alloc& ba) {
 		}
 	}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'lpGuidRet' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. interpretprop2.cpp 293