### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/MAPI/MAPIFunctions.cpp
+++ b/MAPI/MAPIFunctions.cpp
@@ -2269,23 +2269,27 @@ _Check_return_ wstring DecodeID(ULONG cbBuffer, _In_count_(cbBuffer) LPBYTE lpbB
 
 	auto cbDecodedBuffer = cbBuffer / 2;
 	// Allocate memory for lpDecoded
-	auto lpDecoded = new BYTE[cbDecodedBuffer];
-	if (!lpDecoded) return emptystring;
+	try {
+		auto lpDecoded = new BYTE[cbDecodedBuffer];
 
-	// Subtract kwBaseOffset from every character and place result in lpDecoded
-	auto lpwzSrc = reinterpret_cast<LPWSTR>(lpbBuffer);
-	auto lpDst = lpDecoded;
-	for (ULONG i = 0; i < cbDecodedBuffer; i++, lpwzSrc++, lpDst++)
-	{
-		*lpDst = static_cast<BYTE>(*lpwzSrc - kwBaseOffset);
+		// Subtract kwBaseOffset from every character and place result in lpDecoded
+		auto lpwzSrc = reinterpret_cast<LPWSTR>(lpbBuffer);
+		auto lpDst = lpDecoded;
+		for (ULONG i = 0; i < cbDecodedBuffer; i++, lpwzSrc++, lpDst++)
+		{
+			*lpDst = static_cast<BYTE>(*lpwzSrc - kwBaseOffset);
+		}
+
+		auto szBin = BinToHexString(
+			lpDecoded,
+			cbDecodedBuffer,
+			true);
+		delete[] lpDecoded;
+		return szBin;
 	}
-
-	auto szBin = BinToHexString(
-		lpDecoded,
-		cbDecodedBuffer,
-		true);
-	delete[] lpDecoded;
-	return szBin;
+	catch (std::bad_alloc& ba) {
+		return emptystring;
+	}
 }
 
 HRESULT HrEmsmdbUIDFromStore(_In_ LPMAPISESSION pmsess,

--- a/UI/MAPIFormFunctions.cpp
+++ b/UI/MAPIFormFunctions.cpp
@@ -58,17 +58,16 @@ _Check_return_ HRESULT CreateAndDisplayNewMailInFolder(
 				&lpMessage));
 			if (lpMessage)
 			{
-				auto lpMAPIFormViewer = new CMyMAPIFormViewer(
-					hwndParent,
-					lpMDB,
-					lpMAPISession,
-					lpFolder,
-					lpMessage,
-					lpContentsTableListCtrl,
-					iItem);
+				try {
+					auto lpMAPIFormViewer = new CMyMAPIFormViewer(
+						hwndParent,
+						lpMDB,
+						lpMAPISession,
+						lpFolder,
+						lpMessage,
+						lpContentsTableListCtrl,
+						iItem);
 
-				if (lpMAPIFormViewer)
-				{
 					// put everything together with the default info
 					EC_MAPI(lpPersistMessage->InitNew(
 						static_cast<LPMAPIMESSAGESITE>(lpMAPIFormViewer),
@@ -90,6 +89,8 @@ _Check_return_ HRESULT CreateAndDisplayNewMailInFolder(
 					}
 
 					lpMAPIFormViewer->Release();
+				}
+				catch (std::bad_alloc& ba) {
 				}
 
 				lpMessage->Release();
@@ -154,17 +155,16 @@ _Check_return_ HRESULT OpenMessageNonModal(
 			0,
 			&ulMessageStatus));
 
-		auto lpMAPIFormViewer = new CMyMAPIFormViewer(
-			hwndParent,
-			lpMDB,
-			lpMAPISession,
-			lpSourceFolder,
-			lpMessage,
-			lpContentsTableListCtrl,
-			iItem);
+		try {
+			auto lpMAPIFormViewer = new CMyMAPIFormViewer(
+				hwndParent,
+				lpMDB,
+				lpMAPISession,
+				lpSourceFolder,
+				lpMessage,
+				lpContentsTableListCtrl,
+				iItem);
 
-		if (lpMAPIFormViewer)
-		{
 			LPMAPIFORMMGR lpMAPIFormMgr = nullptr;
 			LPMAPIFORM lpForm = nullptr;
 
@@ -219,6 +219,8 @@ _Check_return_ HRESULT OpenMessageNonModal(
 				lpForm->Release();
 			}
 			lpMAPIFormViewer->Release();
+		}
+		catch (std::bad_alloc& ba) {
 		}
 
 		MAPIFreeBuffer(lpspvaShow);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. mapi*