### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/MyMAPIFormViewer.cpp
+++ b/UI/MyMAPIFormViewer.cpp
@@ -233,7 +233,7 @@ STDMETHODIMP CMyMAPIFormViewer::NewMessage(ULONG fComposeInFolder,
 		if (*ppMessage) // not going to release this because we're returning it
 		{
 			// don't free since we're passing it back
-			auto lpMAPIFormViewer = new CMyMAPIFormViewer(
+			auto lpMAPIFormViewer = new (std::nothrow) CMyMAPIFormViewer(
 				m_hwndParent,
 				m_lpMDB,
 				m_lpMAPISession,


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'lpMAPIFormViewer' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. mymapiformviewer.cpp 244