### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/MyWinApp.cpp
+++ b/UI/MyWinApp.cpp
@@ -57,7 +57,7 @@ BOOL CMyWinApp::InitInstance()
 	if (pWnd)
 	{
 		m_pMainWnd = static_cast<CWnd *>(pWnd);
-		auto MyObjects = new CMapiObjects(nullptr);
+		auto MyObjects = new (std::nothrow) CMapiObjects(nullptr);
 		if (MyObjects)
 		{
 			new CMainDlg(pWnd, MyObjects);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'MyObjects' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. mywinapp.cpp 61