### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/MAPI/NamedPropCache.cpp
+++ b/MAPI/NamedPropCache.cpp
@@ -92,7 +92,7 @@ NamedPropCacheEntry::NamedPropCacheEntry(
 
 	if (lpPropName)
 	{
-		lpmniName = new MAPINAMEID;
+		lpmniName = new (std::nothrow) MAPINAMEID;
 
 		if (lpmniName)
 		{


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'lpmniName' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. namedpropcache.cpp 97