### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/IO/Registry.cpp
+++ b/IO/Registry.cpp
@@ -154,7 +154,7 @@ wstring ReadStringFromRegistry(_In_ HKEY hKey, _In_ const wstring& szValue, _In_
 
 	if (S_OK == hRes && cb  && !(cb % 2) && REG_SZ == dwKeyType)
 	{
-		szBuf = new BYTE[cb];
+		szBuf = new (std::nothrow) BYTE[cb];
 		if (szBuf)
 		{
 			// Get the current value


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'szBuf' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. registry.cpp 158