### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/Controls/SingleMAPIPropListCtrl.cpp
+++ b/UI/Controls/SingleMAPIPropListCtrl.cpp
@@ -68,7 +68,7 @@ CSingleMAPIPropListCtrl::CSingleMAPIPropListCtrl(
 		auto cchOrder = RegKeys[regkeyPROP_COLUMN_ORDER].szCurSTRING.length();
 		if (SUCCEEDED(hRes) && nColumnCount == static_cast<int>(cchOrder))
 		{
-			auto pnOrder = new int[nColumnCount];
+			auto pnOrder = new (std::nothrow) int[nColumnCount];
 
 			if (pnOrder)
 			{
@@ -149,7 +149,7 @@ _Check_return_ LRESULT CSingleMAPIPropListCtrl::msgOnSaveColumnOrder(WPARAM /*wP
 		ULONG nColumnCount = lpMyHeader->GetItemCount();
 		if (nColumnCount && nColumnCount <= MAX_SORT_COLS)
 		{
-			auto pnOrder = new int[nColumnCount];
+			auto pnOrder = new (std::nothrow) int[nColumnCount];
 
 			if (pnOrder)
 			{
@@ -1186,7 +1186,7 @@ void CSingleMAPIPropListCtrl::OnDisplayPropertyAsSecurityDescriptorPropSheet() c
 
 	DebugPrintEx(DBGGeneric, CLASS, L"OnDisplayPropertyAsSecurityDescriptorPropSheet", L"interpreting 0x%X as Security Descriptor\n", ulPropTag);
 
-	auto MySecInfo = new CMySecInfo(m_lpPropBag->GetMAPIProp(), ulPropTag);
+	auto MySecInfo = new (std::nothrow) CMySecInfo(m_lpPropBag->GetMAPIProp(), ulPropTag);
 
 	if (MySecInfo)
 	{


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. singlemapiproplistctrl.cpp