### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Interpret/SmartView/SmartView.cpp
+++ b/Interpret/SmartView/SmartView.cpp
@@ -77,19 +77,19 @@ LPSMARTVIEWPARSER GetSmartViewParser(__ParsingTypeEnum iStructType, _In_opt_ LPM
 		return new EntryList();
 	case IDS_STRULECONDITION:
 	{
-		auto parser = new RuleCondition();
+		auto parser = new (std::nothrow) RuleCondition();
 		if (parser) parser->Init(false);
 		return parser;
 	}
 	case IDS_STEXTENDEDRULECONDITION:
 	{
-		auto parser = new RuleCondition();
+		auto parser = new (std::nothrow) RuleCondition();
 		if (parser) parser->Init(true);
 		return parser;
 	}
 	case IDS_STRESTRICTION:
 	{
-		auto parser = new RestrictionStruct();
+		auto parser = new (std::nothrow) RestrictionStruct();
 		if (parser) parser->Init(false, true);
 		return parser;
 	}
@@ -119,13 +119,13 @@ LPSMARTVIEWPARSER GetSmartViewParser(__ParsingTypeEnum iStructType, _In_opt_ LPM
 		return new SIDBin();
 	case IDS_STSECURITYDESCRIPTOR:
 	{
-		auto parser = new SDBin();
+		auto parser = new (std::nothrow) SDBin();
 		if (parser) parser->Init(lpMAPIProp, false);
 		return parser;
 	}
 	case IDS_STFBSECURITYDESCRIPTOR:
 	{
-		auto parser = new SDBin();
+		auto parser = new (std::nothrow) SDBin();
 		if (parser) parser->Init(lpMAPIProp, true);
 		return parser;
 	}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. smartview.cpp