### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Interpret/String.cpp
+++ b/Interpret/String.cpp
@@ -467,7 +467,7 @@ LPBYTE ByteVectorToLPBYTE(const vector<BYTE>& bin)
 {
 	if (bin.empty()) return nullptr;
 
-	auto lpBin = new BYTE[bin.size()];
+	auto lpBin = new (std::nothrow) BYTE[bin.size()];
 	if (lpBin != nullptr)
 	{
 		memset(lpBin, 0, bin.size());


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'lpBin' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. string.cpp 471