### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/MAPI/StubUtils.cpp
+++ b/MAPI/StubUtils.cpp
@@ -228,7 +228,7 @@ HKEY GetHKeyMapiClient(const wstring& pwzProviderOverride)
 	wstring defaultClient;
 	if (hMailKey && pwzProvider.empty())
 	{
-		auto rgchMailClient = new WCHAR[MAX_PATH];
+		auto rgchMailClient = new (std::nothrow) WCHAR[MAX_PATH];
 		if (rgchMailClient)
 		{
 			// Get Outlook application path registry value
@@ -445,7 +445,7 @@ wstring GetOutlookPath(_In_ const wstring& szCategory, _Out_opt_ bool* lpb64)
 	if (ERROR_SUCCESS == ret)
 	{
 		dwValueBuf += 1;
-		auto lpszTempPath = new WCHAR[dwValueBuf];
+		auto lpszTempPath = new (std::nothrow) WCHAR[dwValueBuf];
 
 		if (lpszTempPath != nullptr)
 		{


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. stubutils.cpp