### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/ViewPane/CheckPane.cpp
+++ b/UI/ViewPane/CheckPane.cpp
@@ -6,7 +6,7 @@ static wstring CLASS = L"CheckPane";
 
 CheckPane* CheckPane::Create(UINT uidLabel, bool bVal, bool bReadOnly)
 {
-	auto pane = new CheckPane();
+	auto pane = new (std::nothrow) CheckPane();
 	if (pane)
 	{
 		pane->m_bCheckValue = bVal;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'pane' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. checkpane.cpp 10