### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/ViewPane/CountedTextPane.cpp
+++ b/UI/ViewPane/CountedTextPane.cpp
@@ -6,7 +6,7 @@ static wstring CLASS = L"CountedTextPane";
 
 CountedTextPane* CountedTextPane::Create(UINT uidLabel, bool bReadOnly, UINT uidCountLabel)
 {
-	auto lpPane = new CountedTextPane();
+	auto lpPane = new (std::nothrow) CountedTextPane();
 	if (lpPane)
 	{
 		lpPane->m_szCountLabel = loadstring(uidCountLabel);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'lpPane' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. countedtextpane.cpp 10