### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/ViewPane/DropDownPane.cpp
+++ b/UI/ViewPane/DropDownPane.cpp
@@ -8,7 +8,7 @@ static wstring CLASS = L"DropDownPane";
 
 DropDownPane* DropDownPane::Create(UINT uidLabel, ULONG ulDropList, _In_opt_count_(ulDropList) UINT* lpuidDropList, bool bReadOnly)
 {
-	auto pane = new DropDownPane();
+	auto pane = new (std::nothrow) DropDownPane();
 	if (pane && lpuidDropList)
 	{
 		for (ULONG iDropNum = 0; iDropNum < ulDropList; iDropNum++)
@@ -27,7 +27,7 @@ DropDownPane* DropDownPane::Create(UINT uidLabel, ULONG ulDropList, _In_opt_coun
 
 DropDownPane* DropDownPane::CreateGuid(UINT uidLabel, bool bReadOnly)
 {
-	auto pane = new DropDownPane();
+	auto pane = new (std::nothrow) DropDownPane();
 	if (pane)
 	{
 		for (ULONG iDropNum = 0; iDropNum < PropGuidArray.size(); iDropNum++)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. dropdownpane.cpp