### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/ViewPane/ListPane.cpp
+++ b/UI/ViewPane/ListPane.cpp
@@ -6,7 +6,7 @@ static wstring CLASS = L"ListPane";
 
 ListPane* ListPane::Create(UINT uidLabel, bool bAllowSort, bool bReadOnly, DoListEditCallback callback)
 {
-	auto pane = new ListPane();
+	auto pane = new (std::nothrow) ListPane();
 	if (pane)
 	{
 		pane->Setup(bAllowSort, callback);
@@ -18,7 +18,7 @@ ListPane* ListPane::Create(UINT uidLabel, bool bAllowSort, bool bReadOnly, DoLis
 
 ListPane* ListPane::CreateCollapsibleListPane(UINT uidLabel, bool bAllowSort, bool bReadOnly, DoListEditCallback callback)
 {
-	auto pane = new ListPane();
+	auto pane = new (std::nothrow) ListPane();
 	if (pane)
 	{
 		pane->Setup(bAllowSort, callback);
@@ -258,7 +258,7 @@ void ListPane::SetColumnType(int nCol, ULONG ulPropType) const
 	if (lpMyHeader)
 	{
 		hdItem.mask = HDI_LPARAM;
-		auto lpHeaderData = new HeaderData; // Will be deleted in CSortListCtrl::DeleteAllColumns
+		auto lpHeaderData = new (std::nothrow) HeaderData; // Will be deleted in CSortListCtrl::DeleteAllColumns
 		if (lpHeaderData)
 		{
 			lpHeaderData->ulTagArrayRow = NULL;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. listpane.cpp