### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/UI/ViewPane/SmartViewPane.cpp
+++ b/UI/ViewPane/SmartViewPane.cpp
@@ -7,7 +7,7 @@ static wstring CLASS = L"SmartViewPane";
 
 SmartViewPane* SmartViewPane::Create(UINT uidLabel)
 {
-	auto pane = new SmartViewPane();
+	auto pane = new (std::nothrow) SmartViewPane();
 	if (pane)
 	{
 		pane->SetLabel(uidLabel, true);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'pane' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. smartviewpane.cpp 11