### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/MrMapi/MMSmartView.cpp
+++ b/MrMapi/MMSmartView.cpp
@@ -32,7 +32,7 @@ void DoSmartView(_In_ MYOPTIONS ProgOpts)
 			auto iDesc = _fileno(fIn);
 			auto iLength = _filelength(iDesc);
 
-			auto lpbIn = new BYTE[iLength + 1]; // +1 for NULL
+			auto lpbIn = new (std::nothrow) BYTE[iLength + 1]; // +1 for NULL
 			if (lpbIn)
 			{
 				memset(lpbIn, 0, sizeof(BYTE)*(iLength + 1));


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'lpbIn' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. mmsmartview.cpp 36