### PR TITLE
Fix callback initialization.

### DIFF
--- a/UI/Dialogs/ContentsTable/ProviderTableDlg.cpp
+++ b/UI/Dialogs/ContentsTable/ProviderTableDlg.cpp
@@ -56,7 +56,7 @@ namespace dialog
 
 	_Check_return_ LPMAPIPROP CProviderTableDlg::OpenItemProp(int iSelectedItem, __mfcmapiModifyEnum /*bModify*/)
 	{
-		if (m_lpContentsTableListCtrl || !m_lpProviderAdmin) return nullptr;
+		if (!m_lpContentsTableListCtrl || !m_lpProviderAdmin) return nullptr;
 		output::DebugPrintEx(DBGOpenItemProp, CLASS, L"OpenItemProp", L"iSelectedItem = 0x%X\n", iSelectedItem);
 
 		LPPROFSECT lpProfSect = nullptr;

--- a/UI/MyWinApp.cpp
+++ b/UI/MyWinApp.cpp
@@ -45,13 +45,13 @@ namespace ui
 		{
 			import::MyHeapSetInformation(nullptr, HeapEnableTerminationOnCorruption, nullptr, 0);
 		}
-
-		mapiui::initCallbacks();
 	}
 
 	// CMyWinApp initialization
 	BOOL CMyWinApp::InitInstance()
 	{
+		mapiui::initCallbacks();
+
 		// Create a parent window that all objects get a pointer to, ensuring we don't
 		// quit this thread until all objects have freed themselves.
 		auto pWnd = new CParentWnd();


### PR DESCRIPTION
initCallbacks was happening during global constructor pass, meaning it could (did) happen before the callbacks we initialized to 0, at which point our intended callbacks were wiped. Moved init to InitInstance which happens after global init.