### PR TITLE
Go ahead and set PST_CONFIG_UNICODE when creating unicode PST

### DIFF
--- a/core/mapi/mapiProfileFunctions.cpp
+++ b/core/mapi/mapiProfileFunctions.cpp
@@ -294,19 +294,27 @@ namespace mapi
 
 			if (lpszPSTPath.empty() || lpszProfileName.empty()) return MAPI_E_INVALID_PARAMETER;
 
-			SPropValue PropVal[2];
-			PropVal[0].ulPropTag = CHANGE_PROP_TYPE(PR_PST_PATH, PT_UNICODE);
-			PropVal[0].Value.lpszW = const_cast<LPWSTR>(lpszPSTPath.c_str());
-			PropVal[1].ulPropTag = PR_PST_PW_SZ_OLD;
-			PropVal[1].Value.lpszA = const_cast<LPSTR>(lpszPassword.c_str());
-
 			if (bUnicodePST)
 			{
+				SPropValue PropVal[3];
+				PropVal[0].ulPropTag = CHANGE_PROP_TYPE(PR_PST_PATH, PT_UNICODE);
+				PropVal[0].Value.lpszW = const_cast<LPWSTR>(lpszPSTPath.c_str());
+				PropVal[1].ulPropTag = PR_PST_CONFIG_FLAGS;
+				PropVal[1].Value.ul = PST_CONFIG_UNICODE;
+				PropVal[2].ulPropTag = PR_PST_PW_SZ_OLD;
+				PropVal[2].Value.lpszA = const_cast<LPSTR>(lpszPassword.c_str());
+
 				hRes = EC_H(HrAddServiceToProfile(
-					"MSUPST MS", ulUIParam, NULL, bPasswordSet ? 2 : 1, PropVal, lpszProfileName)); // STRING_OK
+					"MSUPST MS", ulUIParam, NULL, bPasswordSet ? 3 : 2, PropVal, lpszProfileName)); // STRING_OK
 			}
 			else
 			{
+				SPropValue PropVal[2];
+				PropVal[0].ulPropTag = CHANGE_PROP_TYPE(PR_PST_PATH, PT_UNICODE);
+				PropVal[0].Value.lpszW = const_cast<LPWSTR>(lpszPSTPath.c_str());
+				PropVal[1].ulPropTag = PR_PST_PW_SZ_OLD;
+				PropVal[1].Value.lpszA = const_cast<LPSTR>(lpszPassword.c_str());
+
 				hRes = EC_H(HrAddServiceToProfile(
 					"MSPST MS", ulUIParam, NULL, bPasswordSet ? 2 : 1, PropVal, lpszProfileName)); // STRING_OK
 			}


### PR DESCRIPTION
Not doing so leaves the PST in an indeterminate state which can cause problems opening the store.

Repro steps:
1.	In MFCMAPI, go to Tools > Options and check the Use the MDB_ONLINE … checkbox
2.	In the Session menu click Logon and select a profile to log on to, containing at least one mailbox
3.	Double click or click one of the stores in the profile to bring up the folder tree\ store properties and load EMSMDB32.dll
4.	Without logging off, go to the Profile menu and click Show profiles
5.	In the Actions menu, click Create Profile and type in a name for the profile
6.	Select the new profile and in the Actions menu click on Services > Add Unicode PST…
7.	Double click the new profile and select the PST service line
8.	In the Actions menu select Configure Service… 

Expected:
We get the PST config dialog.

Actual:
The result is a dialog box that pops up saying the pst has changed since you last ran Outlook. 
