### PR TITLE
Unicode main

### DIFF
--- a/MrMapi/MrMAPI.cpp
+++ b/MrMapi/MrMAPI.cpp
@@ -126,7 +126,7 @@ bool LoadMAPIVersion(const std::wstring& lpszVersion)
 	return false;
 }
 
-void main(_In_ int argc, _In_count_(argc) char* argv[])
+void wmain(_In_ int argc, _In_count_(argc) wchar_t* argv[])
 {
 	auto hRes = S_OK;
 	auto bMAPIInit = false;

--- a/MrMapi/mmcli.cpp
+++ b/MrMapi/mmcli.cpp
@@ -472,7 +472,7 @@ namespace cli
 			// Print smart view options
 			for (ULONG i = 1; i < SmartViewParserTypeArray.size(); i++)
 			{
-				_tprintf(_T("   %2lu %ws\n"), i, SmartViewParserTypeArray[i].lpszName);
+				wprintf(L"   %2lu %ws\n", i, SmartViewParserTypeArray[i].lpszName);
 			}
 
 			wprintf(L"\n");

--- a/UnitTest/tests/clitest.cpp
+++ b/UnitTest/tests/clitest.cpp
@@ -1,4 +1,4 @@
-#include <UnitTest/stdafx.h>
+﻿#include <UnitTest/stdafx.h>
 #include <UnitTest/UnitTest.h>
 #include <core/utility/cli.h>
 
@@ -62,10 +62,12 @@ namespace clitest
 		TEST_METHOD(Test_GetCommandLine)
 		{
 			//	std::vector<std::wstring> GetCommandLine(_In_ int argc, _In_count_(argc) const char* const argv[]);
-			auto noarg = std::vector<LPCSTR>{"app.exe"};
+			auto noarg = std::vector<LPCWSTR>{L"app.exe"};
 			Assert::AreEqual({}, cli::GetCommandLine(static_cast<int>(noarg.size()), noarg.data()));
-			auto argv = std::vector<LPCSTR>{"app.exe", "-arg1", "-arg2", "test�"};
-			Assert::AreEqual({L"-arg1", L"-arg2", L"test�"}, cli::GetCommandLine(static_cast<int>(argv.size()), argv.data()));
+			auto argv = std::vector<LPCWSTR>{L"app.exe", L"-arg1", L"-arg2", L"testü", L"ěřů"};
+			Assert::AreEqual(
+				{L"-arg1", L"-arg2", L"testü", L"ěřů"},
+				cli::GetCommandLine(static_cast<int>(argv.size()), argv.data()));
 		}
 
 		TEST_METHOD(Test_GetOption)

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -223,7 +223,7 @@ namespace mapi::processor
 		if (m_szFolderPath.empty()) return;
 		if (m_bOutputList)
 		{
-			_tprintf(_T("Subject, Message Class, Filename\n"));
+			wprintf(L"Subject, Message Class, Filename\n");
 			return;
 		}
 

--- a/core/utility/cli.cpp
+++ b/core/utility/cli.cpp
@@ -112,13 +112,13 @@ namespace cli
 	}
 
 	// Converts an argc/argv style command line to a vector
-	std::deque<std::wstring> GetCommandLine(_In_ int argc, _In_count_(argc) const char* const argv[])
+	std::deque<std::wstring> GetCommandLine(_In_ int argc, _In_count_(argc) const wchar_t* const argv[])
 	{
 		auto args = std::deque<std::wstring>{};
 
 		for (auto i = 1; i < argc; i++)
 		{
-			args.emplace_back(strings::LPCSTRToWstring(argv[i]));
+			args.emplace_back(argv[i]);
 		}
 
 		return args;

--- a/core/utility/cli.h
+++ b/core/utility/cli.h
@@ -86,7 +86,7 @@ namespace cli
 	// IE trying to change the mode from anything but unset will fail
 	bool bSetMode(_In_ int& pMode, _In_ int targetMode) noexcept;
 
-	std::deque<std::wstring> GetCommandLine(_In_ int argc, _In_count_(argc) const char* const argv[]);
+	std::deque<std::wstring> GetCommandLine(_In_ int argc, _In_count_(argc) const wchar_t* const argv[]);
 
 	// Parses command line arguments and fills out OPTIONS
 	void ParseArgs(OPTIONS& options, std::deque<std::wstring>& args, const std::vector<option*>& optionsArray);


### PR DESCRIPTION
Ascii main was losing unicode chars in args, so switch to unicode
Fixes #402 