### PR TITLE
Model refinements

### DIFF
--- a/UI/Controls/SortList/SingleMAPIPropListCtrl.cpp
+++ b/UI/Controls/SortList/SingleMAPIPropListCtrl.cpp
@@ -438,6 +438,7 @@ namespace controls::sortlistctrl
 	// Render the row model in the list.
 	void CSingleMAPIPropListCtrl::AddPropToListBox(int iRow, std::shared_ptr<model::mapiRowModel> model)
 	{
+		if (!model) return;
 		auto ulPropTag = model->ulPropTag();
 		auto image = sortIcon::siDefault;
 		for (const auto& _PropTypeIcon : _PropTypeIcons)

--- a/core/mapi/cache/namedPropCache.cpp
+++ b/core/mapi/cache/namedPropCache.cpp
@@ -326,7 +326,7 @@ namespace cache
 		if (!lpMAPIProp) return {};
 
 		// If this is a get all names call, we have to go direct to MAPI since we cannot trust the cache is full.
-		if (!*lppPropTags)
+		if (!lppPropTags || !*lppPropTags)
 		{
 			output::DebugPrint(output::dbgLevel::NamedPropCache, L"GetNamesFromIDs: making direct all for all props\n");
 			LPSPropTagArray pProps = nullptr;

--- a/core/mapi/cache/namedProps.cpp
+++ b/core/mapi/cache/namedProps.cpp
@@ -178,8 +178,9 @@ namespace cache
 
 	// No signature form: look up and use signature if possible
 	_Check_return_ std::vector<std::shared_ptr<namedPropCacheEntry>>
-	GetNamesFromIDs(_In_ LPMAPIPROP lpMAPIProp, _In_opt_ LPSPropTagArray* lppPropTags, ULONG ulFlags)
+	GetNamesFromIDs(_In_opt_ LPMAPIPROP lpMAPIProp, _In_opt_ LPSPropTagArray* lppPropTags, ULONG ulFlags)
 	{
+		if (!lpMAPIProp) return {};
 		SBinary sig = {};
 		LPSPropValue lpProp = nullptr;
 		// This error is too chatty to log - ignore it.
@@ -196,7 +197,7 @@ namespace cache
 
 	// Signature form: if signature is empty then do not use a signature
 	_Check_return_ std::vector<std::shared_ptr<namedPropCacheEntry>> GetNamesFromIDs(
-		_In_ LPMAPIPROP lpMAPIProp,
+		_In_opt_ LPMAPIPROP lpMAPIProp,
 		_In_opt_ const SBinary* sig,
 		_In_opt_ LPSPropTagArray* lppPropTags,
 		ULONG ulFlags)

--- a/core/mapi/cache/namedProps.h
+++ b/core/mapi/cache/namedProps.h
@@ -86,10 +86,10 @@ namespace cache
 
 	// No signature form: look up and use signature if possible
 	_Check_return_ std::vector<std::shared_ptr<namedPropCacheEntry>>
-	GetNamesFromIDs(_In_ LPMAPIPROP lpMAPIProp, _In_opt_ LPSPropTagArray* lppPropTags, ULONG ulFlags);
+	GetNamesFromIDs(_In_opt_ LPMAPIPROP lpMAPIProp, _In_opt_ LPSPropTagArray* lppPropTags, ULONG ulFlags);
 	// Signature form: if signature not passed then do not use a signature
 	_Check_return_ std::vector<std::shared_ptr<namedPropCacheEntry>> GetNamesFromIDs(
-		_In_ LPMAPIPROP lpMAPIProp,
+		_In_opt_ LPMAPIPROP lpMAPIProp,
 		_In_opt_ const SBinary* sig,
 		_In_opt_ LPSPropTagArray* lppPropTags,
 		ULONG ulFlags);

--- a/core/model/mapiRowModel.cpp
+++ b/core/model/mapiRowModel.cpp
@@ -19,7 +19,6 @@ namespace model
 		_In_opt_ const SBinary* sig,
 		_In_opt_ const MAPINAMEID* lpNameID)
 	{
-		if (!lpPropVal) return {};
 		auto ret = std::make_shared<model::mapiRowModel>();
 		ret->ulPropTag(ulPropTag);
 
@@ -40,17 +39,20 @@ namespace model
 
 		ret->otherName(propTagNames.otherMatches);
 
-		std::wstring PropString;
-		std::wstring AltPropString;
-		property::parseProperty(lpPropVal, &PropString, &AltPropString);
-		ret->value(PropString);
-		ret->altValue(AltPropString);
-
 		if (!namePropNames.name.empty()) ret->namedPropName(namePropNames.name);
 		if (!namePropNames.guid.empty()) ret->namedPropGuid(namePropNames.guid);
 
-		const auto szSmartView = smartview::parsePropertySmartView(lpPropVal, lpProp, lpNameID, sig, bIsAB, false);
-		if (!szSmartView.empty()) ret->smartView(szSmartView);
+		if (lpPropVal)
+		{
+			std::wstring PropString;
+			std::wstring AltPropString;
+			property::parseProperty(lpPropVal, &PropString, &AltPropString);
+			ret->value(PropString);
+			ret->altValue(AltPropString);
+
+			const auto szSmartView = smartview::parsePropertySmartView(lpPropVal, lpProp, lpNameID, sig, bIsAB, false);
+			if (!szSmartView.empty()) ret->smartView(szSmartView);
+		}
 
 		return ret;
 	}


### PR DESCRIPTION
propToModelInternal was returning an empty model for getprop misses, which meant the prop could never show in the list. Build out a better model in this case.

AddPropToListBox broke on empty models. After propToModelInternal  fix hopefully this doesn't happen, but we should no-op in that case

GetNamesFromIDs crashes on null lpMAPIProp