### PR TITLE
Bad Named Props In MSG Exports

### DIFF
--- a/UnitTest/tests/namedproptest.cpp
+++ b/UnitTest/tests/namedproptest.cpp
@@ -60,52 +60,35 @@ namespace namedproptest
 		TEST_METHOD(Test_Match)
 		{
 			// Test all forms of match
-			Assert::AreEqual(true, formStorage1->match(formStorage1, true, true, true));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, false, true, true));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, true, false, true));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, true, true, false));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, true, false, false));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, false, true, false));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, false, false, true));
-			Assert::AreEqual(true, formStorage1->match(formStorage1, false, false, false));
+			Assert::AreEqual(true, formStorage1->match(formStorage1, true, true));
+			Assert::AreEqual(true, formStorage1->match(formStorage1, false, true));
+			Assert::AreEqual(true, formStorage1->match(formStorage1, true, false));
+			Assert::AreEqual(true, formStorage1->match(formStorage1, false, false));
 
 			// Odd comparisons
 			Assert::AreEqual(
-				true,
-				formStorage1->match(cache::namedPropCacheEntry::make(&formStorageID, 0x1111, sig1), true, true, true));
+				true, formStorage1->match(cache::namedPropCacheEntry::make(&formStorageID, 0x1111, sig1), true, true));
+			Assert::AreEqual(
+				true, formStorage1->match(cache::namedPropCacheEntry::make(&formStorageID, 0x1112, sig1), false, true));
 			Assert::AreEqual(
 				true,
-				formStorage1->match(cache::namedPropCacheEntry::make(&formStorageID, 0x1112, sig1), true, false, true));
+				formStorage1->match(cache::namedPropCacheEntry::make(&pageDirStreamID, 0x1111, sig1), true, false));
 			Assert::AreEqual(
 				true,
-				formStorage1->match(
-					cache::namedPropCacheEntry::make(&pageDirStreamID, 0x1111, sig1), true, true, false));
-			Assert::AreEqual(
-				true,
-				formStorage1->match(
-					cache::namedPropCacheEntry::make(&formStorageName, 0x1111, sig1), true, true, false));
+				formStorage1->match(cache::namedPropCacheEntry::make(&formStorageName, 0x1111, sig1), true, false));
 			Assert::AreEqual(
 				false,
-				formStorage1->match(
-					cache::namedPropCacheEntry::make(&formStorageName, 0x1111, sig1), true, true, true));
+				formStorage1->match(cache::namedPropCacheEntry::make(&formStorageName, 0x1111, sig1), true, true));
 
 			// Should fail
 			Assert::AreEqual(
-				false,
-				formStorage1->match(cache::namedPropCacheEntry::make(&formStorageID, 0x1110, sig1), true, true, true));
+				false, formStorage1->match(cache::namedPropCacheEntry::make(&formStorageID, 0x1110, sig1), true, true));
 			Assert::AreEqual(
 				false,
-				formStorage1->match(
-					cache::namedPropCacheEntry::make(&pageDirStreamID, 0x1111, sig1), true, true, true));
-			Assert::AreEqual(false, formStorage1->match(nullptr, true, true, true));
-			Assert::AreEqual(false, formStorage1->match(formStorage2, true, true, true));
-			Assert::AreEqual(false, formStorage1->match(formStorageLog, true, true, true));
-
-			// Should all work
-			Assert::AreEqual(true, formStorage1->match(formStorage2, false, true, true));
-			Assert::AreEqual(true, formStorage1->match(formStorage2, false, false, true));
-			Assert::AreEqual(true, formStorage1->match(formStorage2, false, true, false));
-			Assert::AreEqual(true, formStorage1->match(formStorage2, false, false, false));
+				formStorage1->match(cache::namedPropCacheEntry::make(&pageDirStreamID, 0x1111, sig1), true, true));
+			Assert::AreEqual(false, formStorage1->match(nullptr, true, true));
+			Assert::AreEqual(false, formStorage1->match(formStorage2, true, true));
+			Assert::AreEqual(false, formStorage1->match(formStorageLog, true, true));
 
 			// Compare given a signature, MAPINAMEID
 			// _Check_return_ bool match(_In_ const std::vector<BYTE>& _sig, _In_ const MAPINAMEID& _mapiNameId) const;
@@ -134,41 +117,56 @@ namespace namedproptest
 			Assert::AreEqual(false, formStorageProp->match(0x1111, formStorageName2));
 
 			// String prop
-			Assert::AreEqual(true, formStorageProp->match(formStorageProp, true, true, true));
-			Assert::AreEqual(false, formStorageProp->match(formStorageProp1, true, true, true));
+			Assert::AreEqual(true, formStorageProp->match(formStorageProp, true, true));
+			Assert::AreEqual(false, formStorageProp->match(formStorageProp1, true, true));
 		}
 
 		TEST_METHOD(Test_Cache)
 		{
-			cache::namedPropCache::add(ids1, sig1);
-			cache::namedPropCache::add(ids1, {});
-			cache::namedPropCache::add(ids2, {});
+			cache::namedPropCache::add(ids1, sig1); // Add prop1, prop2 with signature
+			cache::namedPropCache::add(ids1, {}); // Try to add them again without signature - this is a no-op
+			cache::namedPropCache::add(ids2, {}); // Again, adding without a signature is a no op
 
+			Assert::AreEqual(true, cache::namedPropCache::find(prop1, true, true)->match(prop1, true, true));
+			Assert::AreEqual(true, cache::namedPropCache::find(prop2, true, true)->match(prop2, true, true));
 			Assert::AreEqual(
-				true, cache::namedPropCache::find(prop1, true, true, true)->match(prop1, true, true, true));
-			Assert::AreEqual(
-				true, cache::namedPropCache::find(prop2, true, true, true)->match(prop2, true, true, true));
-			Assert::AreEqual(
-				true, cache::namedPropCache::find(prop3, true, true, true)->match(prop3, true, true, true));
-			Assert::AreEqual(true, cache::namedPropCache::find(0x1111, formStorageID)->match(prop1, true, true, true));
-			Assert::AreEqual(true, cache::namedPropCache::find(sig1, 0x1111)->match(prop1, true, true, true));
-			Assert::AreEqual(true, cache::namedPropCache::find(sig1, formStorageID)->match(prop1, true, true, true));
+				true,
+				cache::namedPropCache::find(prop3, true, true)
+					->match(cache::namedPropCacheEntry::empty(), true, true)); // Shouldn't find prop3 in the cache
+			Assert::AreEqual(true, cache::namedPropCache::find(0x1111, formStorageID)->match(prop1, true, true));
+			Assert::AreEqual(true, cache::namedPropCache::find(sig1, 0x1111)->match(prop1, true, true));
+			Assert::AreEqual(true, cache::namedPropCache::find(sig1, formStorageID)->match(prop1, true, true));
 
 			Assert::AreEqual(
 				true,
 				cache::namedPropCache::find(0x1110, formStorageID)
-					->match(cache::namedPropCacheEntry::empty(), true, true, true));
+					->match(cache::namedPropCacheEntry::empty(), true, true));
 
-			Assert::AreEqual(false, cache::namedPropCache::find(0x1110, formStorageID)->match(prop1, true, true, true));
-			Assert::AreEqual(false, cache::namedPropCache::find(sig2, 0x1111)->match(prop1, true, true, true));
-			Assert::AreEqual(false, cache::namedPropCache::find(sig2, formStorageID)->match(prop1, true, true, true));
+			Assert::AreEqual(false, cache::namedPropCache::find(0x1110, formStorageID)->match(prop1, true, true));
+			Assert::AreEqual(false, cache::namedPropCache::find(sig2, 0x1111)->match(prop1, true, true));
+			Assert::AreEqual(false, cache::namedPropCache::find(sig2, formStorageID)->match(prop1, true, true));
 
-			Assert::AreEqual(
-				true, cache::namedPropCache::find(0x3333, pageDirStreamID)->match(prop3, true, true, true));
-			Assert::AreEqual(true, cache::namedPropCache::find({}, 0x3333)->match(prop3, true, true, true));
+			// None of these should match prop3 since we never cached it!
 			Assert::AreEqual(
 				true,
-				cache::namedPropCache::find(std::vector<BYTE>{}, pageDirStreamID)->match(prop3, true, true, true));
+				cache::namedPropCache::find(0x3333, pageDirStreamID)
+					->match(cache::namedPropCacheEntry::empty(), true, true));
+			Assert::AreEqual(
+				true, cache::namedPropCache::find({}, 0x3333)->match(cache::namedPropCacheEntry::empty(), true, true));
+			Assert::AreEqual(
+				true,
+				cache::namedPropCache::find(std::vector<BYTE>{}, pageDirStreamID)
+					->match(cache::namedPropCacheEntry::empty(), true, true));
+
+			cache::namedPropCache::add(ids2, sig2); // Now add prop3 with a signature and our lookups should work
+			Assert::AreEqual(
+				true,
+				cache::namedPropCache::find(prop3, true, true)
+					->match(prop3, true, true)); // Shouldn't find prop3 in the cache
+			Assert::AreEqual(true, cache::namedPropCache::find(0x3333, pageDirStreamID)->match(prop3, true, true));
+			Assert::AreEqual(true, cache::namedPropCache::find({}, 0x3333)->match(prop3, true, true));
+			Assert::AreEqual(
+				true, cache::namedPropCache::find(std::vector<BYTE>{}, pageDirStreamID)->match(prop3, true, true));
 		}
 
 		TEST_METHOD(Test_Valid)

--- a/core/mapi/cache/namedPropCache.h
+++ b/core/mapi/cache/namedPropCache.h
@@ -13,11 +13,6 @@ namespace cache
 			ULONG ulFlags,
 			std::vector<std::shared_ptr<namedPropCacheEntry>> &names);
 
-		// Returns a vector of NamedPropCacheEntry for the input tags
-		// Sourced directly from MAPI
-		_Check_return_ std::vector<std::shared_ptr<namedPropCacheEntry>>
-		GetNamesFromIDs(_In_ LPMAPIPROP lpMAPIProp, _In_ const std::vector<ULONG> tags, ULONG ulFlags);
-
 		// Returns a vector of tags for the input names
 		// Sourced directly from MAPI
 		_Check_return_ LPSPropTagArray
@@ -35,14 +30,11 @@ namespace cache
 	class namedPropCache
 	{
 	private:
-		static std::list<std::shared_ptr<namedPropCacheEntry>>& getCache() noexcept;
-
-		_Check_return_ static std::shared_ptr<namedPropCacheEntry>
-		find(const std::function<bool(const std::shared_ptr<namedPropCacheEntry>&)>& compare);
+		static std::vector<std::shared_ptr<namedPropCacheEntry>>& getCache() noexcept;
 
 	public:
 		_Check_return_ static std::shared_ptr<namedPropCacheEntry>
-		find(const std::shared_ptr<cache::namedPropCacheEntry>& entry, bool bMatchSig, bool bMatchID, bool bMatchName);
+		find(const std::shared_ptr<cache::namedPropCacheEntry>& entry, bool bMatchID, bool bMatchName);
 		_Check_return_ static std::shared_ptr<namedPropCacheEntry>
 		find(_In_ const std::vector<BYTE>& _sig, _In_ const MAPINAMEID& _mapiNameId);
 		_Check_return_ static std::shared_ptr<namedPropCacheEntry>

--- a/core/mapi/cache/namedProps.h
+++ b/core/mapi/cache/namedProps.h
@@ -15,10 +15,7 @@ namespace cache
 	class namedPropCacheEntry
 	{
 	public:
-		namedPropCacheEntry(
-			const MAPINAMEID* lpPropName,
-			ULONG _ulPropID,
-			_In_ const std::vector<BYTE>& _sig = {});
+		namedPropCacheEntry(const MAPINAMEID* lpPropName, ULONG _ulPropID, _In_ const std::vector<BYTE>& _sig = {});
 
 		// Disables making copies of NamedPropCacheEntry
 		namedPropCacheEntry(const namedPropCacheEntry&) = delete;
@@ -53,7 +50,7 @@ namespace cache
 		void setSig(const std::vector<BYTE>& _sig) { sig = _sig; }
 
 		_Check_return_ bool
-		match(const std::shared_ptr<namedPropCacheEntry>& entry, bool bMatchSig, bool bMatchID, bool bMatchName) const;
+		match(const std::shared_ptr<namedPropCacheEntry>& entry, bool bMatchID, bool bMatchName) const;
 
 		// Compare given a signature, MAPINAMEID
 		_Check_return_ bool match(_In_ const std::vector<BYTE>& _sig, _In_ const MAPINAMEID& _mapiNameId) const;
@@ -107,4 +104,8 @@ namespace cache
 	std::vector<std::wstring> NameIDToPropNames(_In_opt_ const MAPINAMEID* lpNameID);
 
 	ULONG FindHighestNamedProp(_In_ LPMAPIPROP lpMAPIProp);
+
+	_Check_return_ std::shared_ptr<namedPropCacheEntry> find(
+		const std::vector<std::shared_ptr<namedPropCacheEntry>>& list,
+		const std::function<bool(const std::shared_ptr<namedPropCacheEntry>&)>& compare);
 } // namespace cache

--- a/core/model/mapiRowModel.cpp
+++ b/core/model/mapiRowModel.cpp
@@ -23,7 +23,7 @@ namespace model
 		ret->ulPropTag(ulPropTag);
 
 		const auto propTagNames = proptags::PropTagToPropName(ulPropTag, bIsAB);
-		const auto namePropNames = cache::NameIDToStrings(ulPropTag, lpProp, nullptr, sig, bIsAB);
+		const auto namePropNames = cache::NameIDToStrings(ulPropTag, lpProp, lpNameID, sig, bIsAB);
 		if (!propTagNames.bestGuess.empty())
 		{
 			ret->name(propTagNames.bestGuess);
@@ -112,9 +112,10 @@ namespace model
 		for (ULONG i = 0; i < cValues; i++)
 		{
 			const auto prop = lpPropVals[i];
-			const auto lpNameID =
-				(namedPropCacheEntries.size() > i) ? namedPropCacheEntries[i]->getMapiNameId() : nullptr;
-			models.push_back(model::propToModelInternal(&prop, prop.ulPropTag, lpProp, bIsAB, lpSigBin, lpNameID));
+			const auto lpNameID = cache::find(
+				namedPropCacheEntries, [&](const auto& _entry) { return _entry->getPropID() == PROP_ID(prop.ulPropTag); });
+			models.push_back(
+				model::propToModelInternal(&prop, prop.ulPropTag, lpProp, bIsAB, lpSigBin, lpNameID->getMapiNameId()));
 		}
 
 		if (lpMappingSigFromObject) MAPIFreeBuffer(lpMappingSigFromObject);


### PR DESCRIPTION
Stop adding no signature entries to the cache - we cannot trust entries without a signature