### PR TITLE
Interesting property filter

### DIFF
--- a/MrMapi/MMContents.cpp
+++ b/MrMapi/MMContents.cpp
@@ -16,24 +16,24 @@ void DumpContentsTable(
 	_In_opt_ LPSRestriction lpRes)
 {
 	output::DebugPrint(
-		output::dbgLevel::Generic,
+		output::dbgLevel::Console,
 		L"DumpContentsTable: Outputting folder %ws from profile %ws to %ws\n",
 		lpszFolder,
 		lpszProfile,
 		lpszDir);
 	if (cli::switchContents.isSet())
-		output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: Outputting Contents\n");
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Outputting Contents\n");
 	if (cli::switchAssociatedContents.isSet())
-		output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: Outputting Associated Contents\n");
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Outputting Associated Contents\n");
 	if (cli::switchMSG.isSet())
-		output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: Outputting as MSG\n");
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Outputting as MSG\n");
 	if (cli::switchMoreProperties.isSet())
-		output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: Will retry stream properties\n");
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Will retry stream properties\n");
 	if (cli::switchSkip.isSet())
-		output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: Will skip attachments\n");
-	if (cli::switchList.isSet()) output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: List only mode\n");
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Will skip attachments\n");
+	if (cli::switchList.isSet()) output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: List only mode\n");
 	if (ulCount)
-		output::DebugPrint(output::dbgLevel::Generic, L"DumpContentsTable: Limiting output to %u messages.\n", ulCount);
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Limiting output to %u messages.\n", ulCount);
 
 	if (lpFolder)
 	{
@@ -43,6 +43,17 @@ void DumpContentsTable(
 		MyDumpStore.InitFolder(lpFolder);
 		MyDumpStore.InitFolderPathRoot(lpszDir);
 		MyDumpStore.InitFolderContentsRestriction(lpRes);
+		// If any properties passed in, pass them along.
+		if (cli::switchFindProperty.size() != 0)
+		{
+			MyDumpStore.InitProperties(cli::switchFindProperty);
+		}
+
+		if (cli::switchFindNamedProperty.size() != 0)
+		{
+			MyDumpStore.InitNamedProperties(cli::switchFindNamedProperty);
+		}
+
 		if (cli::switchMSG.isSet()) MyDumpStore.EnableMSG();
 		if (cli::switchList.isSet()) MyDumpStore.EnableList();
 		if (ulCount)

--- a/MrMapi/MrMAPI.cpp
+++ b/MrMapi/MrMAPI.cpp
@@ -143,7 +143,8 @@ int wmain(_In_ int argc, _In_count_(argc) wchar_t* argv[])
 	registry::useGetPropList = true;
 	registry::parseNamedProps = true;
 	registry::cacheNamedProps = true;
-	registry::debugTag = 0;
+	registry::debugTag = static_cast<DWORD>(output::dbgLevel::Console); // Any debug logging with Console will print to the console now
+
 	output::initStubCallbacks();
 
 	SetDllDirectory(_T(""));

--- a/MrMapi/MrMAPI.cpp
+++ b/MrMapi/MrMAPI.cpp
@@ -143,7 +143,8 @@ int wmain(_In_ int argc, _In_count_(argc) wchar_t* argv[])
 	registry::useGetPropList = true;
 	registry::parseNamedProps = true;
 	registry::cacheNamedProps = true;
-	registry::debugTag = static_cast<DWORD>(output::dbgLevel::Console); // Any debug logging with Console will print to the console now
+	registry::debugTag =
+		static_cast<DWORD>(output::dbgLevel::Console); // Any debug logging with Console will print to the console now
 
 	output::initStubCallbacks();
 

--- a/MrMapi/mmcli.cpp
+++ b/MrMapi/mmcli.cpp
@@ -285,14 +285,9 @@ namespace cli
 			switchFlag.name(),
 			switchProfile.name());
 		wprintf(
-			L"   MrMAPI -%ws [-%ws <property names>] [-%ws <folder>] [-%ws <output directory>]\n",
+			L"   MrMAPI -%ws [-%ws <property names>] [-%ws <dispid names>] [-%ws <folder>] [-%ws <output directory>]\n",
 			switchContents.name(),
 			switchFindProperty.name(),
-			switchFolder.name(),
-			switchOutput.name());
-		wprintf(
-			L"   MrMAPI -%ws [-%ws <dispid names>] [-%ws <folder>] [-%ws <output directory>]\n",
-			switchContents.name(),
 			switchFindNamedProperty.name(),
 			switchFolder.name(),
 			switchOutput.name());

--- a/MrMapi/mmcli.cpp
+++ b/MrMapi/mmcli.cpp
@@ -195,7 +195,8 @@ namespace cli
 			switchProfile.name(),
 			switchFolder.name());
 		wprintf(
-			L"   MrMAPI -%ws | -%ws [-%ws <profile>] [-%ws <folder>] [-%ws <property names>] [-%ws <dispid names>] [-%ws <output directory>]\n",
+			L"   MrMAPI -%ws | -%ws [-%ws <profile>] [-%ws <folder>] [-%ws <property names>] [-%ws <dispid names>] "
+			L"[-%ws <output directory>]\n",
 			switchContents.name(),
 			switchAssociatedContents.name(),
 			switchProfile.name(),

--- a/MrMapi/mmcli.cpp
+++ b/MrMapi/mmcli.cpp
@@ -195,11 +195,13 @@ namespace cli
 			switchProfile.name(),
 			switchFolder.name());
 		wprintf(
-			L"   MrMAPI -%ws | -%ws [-%ws <profile>] [-%ws <folder>] [-%ws <output directory>]\n",
+			L"   MrMAPI -%ws | -%ws [-%ws <profile>] [-%ws <folder>] [-%ws <property names>] [-%ws <dispid names>] [-%ws <output directory>]\n",
 			switchContents.name(),
 			switchAssociatedContents.name(),
 			switchProfile.name(),
 			switchFolder.name(),
+			switchFindProperty.name(),
+			switchFindNamedProperty.name(),
 			switchOutput.name());
 		wprintf(
 			L"          [-%ws <subject>] [-%ws <message class>] [-%ws] [-%ws] [-%ws <count>] [-%ws]\n",
@@ -284,13 +286,6 @@ namespace cli
 			switchWizard.name(),
 			switchFlag.name(),
 			switchProfile.name());
-		wprintf(
-			L"   MrMAPI -%ws [-%ws <property names>] [-%ws <dispid names>] [-%ws <folder>] [-%ws <output directory>]\n",
-			switchContents.name(),
-			switchFindProperty.name(),
-			switchFindNamedProperty.name(),
-			switchFolder.name(),
-			switchOutput.name());
 
 		if (bFull)
 		{

--- a/MrMapi/mmcli.cpp
+++ b/MrMapi/mmcli.cpp
@@ -70,6 +70,8 @@ namespace cli
 	option switchAccounts{L"Accounts", cmdmodeEnumAccounts, 0, 0, OPT_INITALL | OPT_PROFILE};
 	option switchIterate{L"Iterate", cmdmodeEnumAccounts, 0, 0, OPT_NOOPT};
 	option switchWizard{L"Wizard", cmdmodeEnumAccounts, 0, 0, OPT_NOOPT};
+	option switchFindProperty{L"FindProperty", cmdmodeContents, 1, USHRT_MAX, OPT_INITALL};
+	option switchFindNamedProperty{L"FindNamedProperty", cmdmodeContents, 1, USHRT_MAX, OPT_INITALL};
 
 	// If we want to add aliases for any switches, add them here
 	option switchHelpAlias{L"Help", cmdmodeHelpFull, 0, 0, OPT_INITMFC};
@@ -129,6 +131,8 @@ namespace cli
 		&switchAccounts,
 		&switchIterate,
 		&switchWizard,
+		&switchFindProperty,
+		&switchFindNamedProperty,
 		// If we want to add aliases for any switches, add them here
 		&switchHelpAlias,
 	};
@@ -280,6 +284,18 @@ namespace cli
 			switchWizard.name(),
 			switchFlag.name(),
 			switchProfile.name());
+		wprintf(
+			L"   MrMAPI -%ws [-%ws <property names>] [-%ws <folder>] [-%ws <output directory>]\n",
+			switchContents.name(),
+			switchFindProperty.name(),
+			switchFolder.name(),
+			switchOutput.name());
+		wprintf(
+			L"   MrMAPI -%ws [-%ws <dispid names>] [-%ws <folder>] [-%ws <output directory>]\n",
+			switchContents.name(),
+			switchFindNamedProperty.name(),
+			switchFolder.name(),
+			switchOutput.name());
 
 		if (bFull)
 		{
@@ -336,6 +352,12 @@ namespace cli
 			wprintf(L"   -Ms  (or -%ws) Output as .MSG instead of XML.\n", switchMSG.name());
 			wprintf(L"   -L   (or -%ws) List details to screen and do not output files.\n", switchList.name());
 			wprintf(L"   -Re  (or -%ws) Restrict output to the 'count' most recent messages.\n", switchRecent.name());
+			wprintf(
+				L"   -FindP  (or -%ws) Restrict output to messages which contain given properties.\n",
+				switchFindProperty.name());
+			wprintf(
+				L"   -FindN  (or -%ws) Restrict output to messages which contain given named properties.\n",
+				switchFindNamedProperty.name());
 			wprintf(L"\n");
 			wprintf(L"   Child Folders:\n");
 			wprintf(L"   -Chi (or -%ws) Display child folders of selected folder.\n", switchChildFolders.name());

--- a/MrMapi/mmcli.h
+++ b/MrMapi/mmcli.h
@@ -54,6 +54,8 @@ namespace cli
 	extern option switchAccounts;
 	extern option switchIterate;
 	extern option switchWizard;
+	extern option switchFindProperty;
+	extern option switchFindNamedProperty;
 
 	extern std::vector<option*> g_options;
 

--- a/core/mapi/cache/namedProps.h
+++ b/core/mapi/cache/namedProps.h
@@ -1,5 +1,7 @@
 #pragma once
 // Named Property Cache
+#include <core/addin/addin.h>
+#include <core/addin/MFCMAPI.h>
 
 namespace cache
 {
@@ -108,4 +110,7 @@ namespace cache
 	_Check_return_ std::shared_ptr<namedPropCacheEntry> find(
 		const std::vector<std::shared_ptr<namedPropCacheEntry>>& list,
 		const std::function<bool(const std::shared_ptr<namedPropCacheEntry>&)>& compare);
+
+	void FindNameIDArrayMatches(_In_ LONG lTarget, _Out_ ULONG* lpulNumExacts, _Out_ ULONG* lpulFirstExact) noexcept;
+	_Check_return_ LPNAMEID_ARRAY_ENTRY GetDispIDFromName(_In_z_ LPCWSTR lpszDispIDName);
 } // namespace cache

--- a/core/mapi/mapiOutput.cpp
+++ b/core/mapi/mapiOutput.cpp
@@ -697,5 +697,6 @@ namespace output
 		}
 
 		Output(ulDbgLvl, fFile, true, strings::StripCarriage(property::RestrictionToString(lpRes, lpObj)));
+		Output(ulDbgLvl, fFile, true, L"\n");
 	}
 } // namespace output

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -647,9 +647,8 @@ namespace mapi::processor
 				recordKey = mapi::getBin(lpRecordKey);
 			}
 
-			MAPIFreeBuffer(lpRecordKey);
-
 			lpMsgData->szFilePath = file::BuildFileNameAndPath(L".xml", szSubj, szFolderPath, &recordKey); // STRING_OK
+			MAPIFreeBuffer(lpRecordKey);
 		}
 	}
 

--- a/core/mapi/processor/dumpStore.h
+++ b/core/mapi/processor/dumpStore.h
@@ -29,6 +29,8 @@ namespace mapi::processor
 		void InitMessagePath(_In_ const std::wstring& szMessageFileName);
 		void InitFolderPathRoot(_In_ const std::wstring& szFolderPathRoot);
 		void InitMailboxTablePathRoot(_In_ const std::wstring& szMailboxTablePathRoot);
+		void InitProperties(const std::vector<std::wstring>& properties);
+		void InitNamedProperties(const std::vector<std::wstring>& namedProperties);
 		void EnableMSG() noexcept;
 		void EnableList() noexcept;
 		void DisableStreamRetry() noexcept;
@@ -70,6 +72,9 @@ namespace mapi::processor
 		void EndAttachmentWork(_In_ LPMESSAGE lpMessage, _In_ LPVOID lpData) override;
 		void EndMessageWork(_In_ LPMESSAGE lpMessage, _In_ LPVOID lpData) override;
 
+		void InitializeInterestingTagArray();
+		bool MessageHasInterestingProperties(_In_ LPMESSAGE lpMessage);
+
 		std::wstring m_szMailboxTablePathRoot;
 		std::wstring m_szFolderPathRoot;
 		std::wstring m_szMessageFileName;
@@ -83,5 +88,9 @@ namespace mapi::processor
 		bool m_bOutputList;
 		bool m_bRetryStreamProps;
 		bool m_bOutputAttachments;
+
+		std::vector<std::wstring> m_properties;
+		std::vector<std::wstring> m_namedProperties;
+		LPSPropTagArray m_lpInterestingPropTags = nullptr;
 	};
 } // namespace mapi::processor

--- a/core/utility/cli.h
+++ b/core/utility/cli.h
@@ -46,6 +46,7 @@ namespace cli
 		}
 		std::wstring at(const size_t _Pos) const noexcept { return size() > _Pos ? args[_Pos] : std::wstring{}; }
 		std::wstring operator[](const size_t _Pos) const noexcept { return at(_Pos); }
+		operator std::vector<std::wstring>&() noexcept { return args; }
 
 		ULONG atULONG(const size_t _Pos, const int radix = 10) const noexcept
 		{

--- a/core/utility/output.h
+++ b/core/utility/output.h
@@ -33,6 +33,7 @@ namespace output
 		LoadMAPI = 0x00080000,
 		Hierarchy = 0x00100000,
 		NamedPropCache = 0x00200000,
+		Console = 0x00400000, // used in MrMAPI to print to console
 		Draw = 0x10000000,
 		UI = 0x20000000,
 		MAPIFunctions = 0x40000000,


### PR DESCRIPTION
Usage - when run like this:
mrmapi -Contents -Folder "Finder\Reminders" -Findn PidLidReminderPlaySound PidLidReminderFileParameter
Will search the folder (in this case, the reminders folder, which is a search folder containing references to all messages which have reminder properties regardless of where they live in the mailbox).
Any message found to contain one of the interesting properties will be output (in this case, the PidLidReminderPlaySound or PidLidReminderFileParameter properties which control what sound will play when a reminder fires).
Output consists of rows of XML style property output giving the subject, parent folder name, entry ID of the message. Also, an XML file consisting of the usual mrmapi/mfcmapi style text export of the interesting message will be output to the output directory, which is here the current directory and can be changed with the -o switch.