### PR TITLE
Interesting prop search recursion

### DIFF
--- a/MrMapi/MMContents.cpp
+++ b/MrMapi/MMContents.cpp
@@ -32,6 +32,8 @@ void DumpContentsTable(
 	if (cli::switchSkip.isSet())
 		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Will skip attachments\n");
 	if (cli::switchList.isSet()) output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: List only mode\n");
+	if (cli::switchRecurse.isSet())
+		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Recurse into subfolders\n");
 	if (ulCount)
 		output::DebugPrint(output::dbgLevel::Console, L"DumpContentsTable: Limiting output to %u messages.\n", ulCount);
 
@@ -70,7 +72,8 @@ void DumpContentsTable(
 		if (!cli::switchMoreProperties.isSet()) MyDumpStore.DisableStreamRetry();
 		if (cli::switchSkip.isSet()) MyDumpStore.DisableEmbeddedAttachments();
 
-		MyDumpStore.ProcessFolders(cli::switchContents.isSet(), cli::switchAssociatedContents.isSet(), false);
+		MyDumpStore.ProcessFolders(
+			cli::switchContents.isSet(), cli::switchAssociatedContents.isSet(), cli::switchRecurse.isSet());
 	}
 }
 

--- a/MrMapi/mmcli.cpp
+++ b/MrMapi/mmcli.cpp
@@ -72,6 +72,7 @@ namespace cli
 	option switchWizard{L"Wizard", cmdmodeEnumAccounts, 0, 0, OPT_NOOPT};
 	option switchFindProperty{L"FindProperty", cmdmodeContents, 1, USHRT_MAX, OPT_INITALL};
 	option switchFindNamedProperty{L"FindNamedProperty", cmdmodeContents, 1, USHRT_MAX, OPT_INITALL};
+	option switchRecurse{L"Recurse", cmdmodeContents, 0, 0, OPT_NOOPT};
 
 	// If we want to add aliases for any switches, add them here
 	option switchHelpAlias{L"Help", cmdmodeHelpFull, 0, 0, OPT_INITMFC};
@@ -133,6 +134,7 @@ namespace cli
 		&switchWizard,
 		&switchFindProperty,
 		&switchFindNamedProperty,
+		&switchRecurse,
 		// If we want to add aliases for any switches, add them here
 		&switchHelpAlias,
 	};
@@ -195,14 +197,11 @@ namespace cli
 			switchProfile.name(),
 			switchFolder.name());
 		wprintf(
-			L"   MrMAPI -%ws | -%ws [-%ws <profile>] [-%ws <folder>] [-%ws <property names>] [-%ws <dispid names>] "
-			L"[-%ws <output directory>]\n",
+			L"   MrMAPI -%ws | -%ws [-%ws <profile>] [-%ws <folder>] [-%ws <output directory>]\n",
 			switchContents.name(),
 			switchAssociatedContents.name(),
 			switchProfile.name(),
 			switchFolder.name(),
-			switchFindProperty.name(),
-			switchFindNamedProperty.name(),
 			switchOutput.name());
 		wprintf(
 			L"          [-%ws <subject>] [-%ws <message class>] [-%ws] [-%ws] [-%ws <count>] [-%ws]\n",
@@ -212,6 +211,11 @@ namespace cli
 			switchList.name(),
 			switchRecent.name(),
 			switchSkip.name());
+		wprintf(
+			L"          [-%ws <property names>] [-%ws <dispid names>] [-%ws]\n",
+			switchFindProperty.name(),
+			switchFindNamedProperty.name(),
+			switchRecurse.name());
 		wprintf(
 			L"   MrMAPI -%ws [-%ws <profile>] [-%ws <folder>]\n",
 			switchChildFolders.name(),
@@ -338,20 +342,22 @@ namespace cli
 			wprintf(
 				L"   -H   (or -%ws) Output associated contents table. May be combined with -C. Profile optional\n",
 				switchAssociatedContents.name());
+			wprintf(L"   -Chi (or -%ws) Recurse into child folders of selected folder.\n", switchChildFolders.name());
 			wprintf(L"   -Su  (or -%ws) Subject of messages to output.\n", switchSubject.name());
 			wprintf(L"   -Me  (or -%ws) Message class of messages to output.\n", switchMessageClass.name());
 			wprintf(L"   -Ms  (or -%ws) Output as .MSG instead of XML.\n", switchMSG.name());
 			wprintf(L"   -L   (or -%ws) List details to screen and do not output files.\n", switchList.name());
-			wprintf(L"   -Re  (or -%ws) Restrict output to the 'count' most recent messages.\n", switchRecent.name());
+			wprintf(L"   -Res (or -%ws) Restrict output to the 'count' most recent messages.\n", switchRecent.name());
 			wprintf(
 				L"   -FindP  (or -%ws) Restrict output to messages which contain given properties.\n",
 				switchFindProperty.name());
 			wprintf(
 				L"   -FindN  (or -%ws) Restrict output to messages which contain given named properties.\n",
 				switchFindNamedProperty.name());
+			wprintf(L"   -Recur  (or -%ws) Recurse into subfolders.\n", switchRecurse.name());
 			wprintf(L"\n");
 			wprintf(L"   Child Folders:\n");
-			wprintf(L"   -Chi (or -%ws) Display child folders of selected folder.\n", switchChildFolders.name());
+			wprintf(L"   -Chi (or -%ws) List child folders of selected folder.\n", switchChildFolders.name());
 			wprintf(L"\n");
 			wprintf(L"   MSG File Properties\n");
 			wprintf(L"   -X   (or -%ws) Output properties of an MSG file as XML.\n", switchXML.name());

--- a/MrMapi/mmcli.h
+++ b/MrMapi/mmcli.h
@@ -56,6 +56,7 @@ namespace cli
 	extern option switchWizard;
 	extern option switchFindProperty;
 	extern option switchFindNamedProperty;
+	extern option switchRecurse;
 
 	extern std::vector<option*> g_options;
 

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -541,7 +541,6 @@ namespace mapi::processor
 
 	bool dumpStore::MessageHasInterestingProperties(_In_ LPMESSAGE lpMessage)
 	{
-		return false;
 		if (!lpMessage || !m_lpInterestingPropTags) return true;
 
 		output::DebugPrint(

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -439,7 +439,6 @@ namespace mapi::processor
 
 	void dumpStore::InitializeInterestingTagArray()
 	{
-
 		auto count = static_cast<ULONG>(m_properties.size() + m_namedProperties.size());
 		if (!m_lpFolder || count == 0) return;
 

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -530,13 +530,18 @@ namespace mapi::processor
 				}
 			}
 
-			//			if (m_lpInterestingPropTags) MAPIFreeBuffer(m_lpInterestingPropTags);
+			if (m_lpInterestingPropTags)
+			{
+				MAPIFreeBuffer(m_lpInterestingPropTags);
+			}
+
 			m_lpInterestingPropTags = lpTag;
 		}
 	}
 
 	bool dumpStore::MessageHasInterestingProperties(_In_ LPMESSAGE lpMessage)
 	{
+		return false;
 		if (!lpMessage || !m_lpInterestingPropTags) return true;
 
 		output::DebugPrint(

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -439,10 +439,21 @@ namespace mapi::processor
 
 	void dumpStore::InitializeInterestingTagArray()
 	{
+
 		auto count = static_cast<ULONG>(m_properties.size() + m_namedProperties.size());
 		if (!m_lpFolder || count == 0) return;
 
-		wprintf(L"Filtering for one of %lu interesting properties\n", count);
+		auto lpDisplayNameW = LPSPropValue{};
+		std::wstring szDisplayName;
+		WC_MAPI_S(mapi::HrGetOnePropEx(m_lpFolder, PR_DISPLAY_NAME_W, fMapiUnicode, &lpDisplayNameW));
+		if (lpDisplayNameW && strings::CheckStringProp(lpDisplayNameW, PT_UNICODE))
+		{
+			szDisplayName = lpDisplayNameW->Value.lpszW;
+		}
+
+		MAPIFreeBuffer(lpDisplayNameW);
+
+		wprintf(L"Filtering %ws for one of %lu interesting properties\n", szDisplayName.c_str(), count);
 		count += boringProps.cValues; // We're going to add some boring properties we'll use later for display
 
 		auto lpTag = mapi::allocate<LPSPropTagArray>(CbNewSPropTagArray(count));
@@ -520,6 +531,7 @@ namespace mapi::processor
 				}
 			}
 
+			//			if (m_lpInterestingPropTags) MAPIFreeBuffer(m_lpInterestingPropTags);
 			m_lpInterestingPropTags = lpTag;
 		}
 	}

--- a/core/mapi/processor/dumpStore.cpp
+++ b/core/mapi/processor/dumpStore.cpp
@@ -213,6 +213,7 @@ namespace mapi::processor
 	void dumpStore::EndFolderWork()
 	{
 		MAPIFreeBuffer(m_lpInterestingPropTags);
+		m_lpInterestingPropTags = nullptr;
 		if (m_bOutputList) return;
 		if (m_fFolderProps)
 		{
@@ -528,11 +529,6 @@ namespace mapi::processor
 
 					MAPIFreeBuffer(lpNamedPropTags);
 				}
-			}
-
-			if (m_lpInterestingPropTags)
-			{
-				MAPIFreeBuffer(m_lpInterestingPropTags);
 			}
 
 			m_lpInterestingPropTags = lpTag;


### PR DESCRIPTION
Added a new -recurse switch to allow an interesting prop search to recurse folders and search down the tree.

For example, this command:
mrmapi -Contents -Folder "@" -recurse -findn PidLidReminderPlaySound PidLidReminderFileParameter
Starts at the root of the message store ("@") and searches every folder underneath it.

Note - many of the folders in a message store are search folders, like the Reminders folder, which don't technically contain any messages but rather contain search results for messages. We don't make any effort to distinguish between the types of folders when doing this recursion, so a message which is in the scope of a search folder may be "found" multiple times. It will appear to live in the folder it actually lives in, as well as any search folder for which it is in scope and matches the criteria.